### PR TITLE
Add rewrite in vercel.json to handle React Router paths on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
normally, when redirected the routing to questionPage, the vercel looks for the exact path which is causing the error. by including rewrites in vercel.json file, vercel takes the react-routing into account and the refresh error doesnt cause anymore.